### PR TITLE
feat: command for clearing cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,13 @@ Or if you installed package globally:
 ```bash
 appcenter-migration-tool -i
 ```
+
+
+# Clear cache
+
+Configuration values like api hostnames are cached. In case you change those values, you'll want to clear the cache. You can do that by running:
+
+```bash
+chmod +x ./bin/clear-cache
+./bin/clear-cache
+```

--- a/bin/clear-cache
+++ b/bin/clear-cache
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../dist/clearCache.js';

--- a/src/clearCache.ts
+++ b/src/clearCache.ts
@@ -1,0 +1,3 @@
+import {clearConfigs} from "./config";
+
+clearConfigs();


### PR DESCRIPTION
Configuration values like [this one for example](https://github.com/appswithlove/updraft-appcenter-migration-tool/blob/main/src/config.ts#L26) are cached. If you change those values, you'll want to clear the cache, so that old values are erased. 

This PR provides an easy way to clear the cache.

It was useful while changing "https://u2.getupdraft.com" -> "'https://getupdraft.com'"