### PR TITLE
feat: show both app name and display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ List the available apps in the specified App Center organization
 
 Migrate the specified app from App Center to existing app in Updraft. This will migrate all app releases from App Center
 to Updraft. Each app release in App Center will correspond to app build in Updraft app. Command parameters:
-- `profileName` - App Center app name for migration to an Updraft
+- `profileName`
+    - App Center app name for migration to an Updraft
+    - **IMPORTANT** - app name, not app display name - you can find app name by using previous two commands for listing apps
 - `owner` - App Center application owner name
 - `updraftAppKey` - Your Updraft app key/token. You find it in 'Edit App'.
 - `updraftApiKey` - Your Updraft api key/token. You find it in 'Profile > Tokens'.

--- a/src/core/writer.ts
+++ b/src/core/writer.ts
@@ -27,6 +27,7 @@ const writersMap: { [key in CommandTypes]: (data: any) => void } = {
             data?.data?.map((app: any) => ({
                 ID: app?.id,
                 Name: app?.name,
+                'Display Name': app?.display_name,
                 'Owner Organization': app?.owner.name,
             })),
         );


### PR DESCRIPTION
At first I thought that in app center, apps can have duplicated names, but that is not the case. Apps can have same display name, but not the same app name. Those two are different fields. Fortunately, our endpoint for getting app releases uses app name, which is unique per each app in app center.

There is one small issue and that is that in app center (as far as I am able to see) the app name is not visible. User only sees the app display name. Therefor, user will have to use our command line tool to get a list of all apps (or apps from some org) where he can see both app name and app display name. That way user can use app name for migrating app binary files.


_Screenshot apps with same display name in app center, appswithlove org_

![imageedit_2_8613175640](https://github.com/user-attachments/assets/fa7ba35a-937b-4d17-bc3c-08551d040d84)


_Screenshot list of apps from appswithlove org, our command line tool where user can see both display name and app name_ 

![imageedit_4_9548509717](https://github.com/user-attachments/assets/1024bb29-3d04-4f26-a83e-0cefaac1db68)


App name, which can not be seen in app center online app, is used for getting app releases and binary files. App name is unique.